### PR TITLE
feat: Add wait-for-images timeout and harden Masonry filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /.luarc.json
 /example.html
 /example_files
+/index.html
+/index_files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-## 0.4.0 (2026-05-28)
-
 ### New Features
 
 - feat: Add `masonry-wait-for-images-timeout` attribute and matching metadata key with an automatic layout fallback when imagesLoaded never fires.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+## 0.4.0 (2026-05-28)
+
+### New Features
+
+- feat: Add `masonry-wait-for-images-timeout` attribute and matching metadata key with an automatic layout fallback when imagesLoaded never fires.
+
+### Bug Fixes
+
+- fix: Reset module-level state at the start of each Pandoc pass so batch renders do not leak metadata defaults, wait-for-images settings, or the imagesLoaded dependency flag between documents.
+- fix: Escape control characters (newline, tab, carriage return, and the full C0 range) in `data-masonry` JSON strings; previously a value containing a literal newline produced invalid JSON.
+
+### Enhancements
+
+- enh: Warn via `quarto.log.warning` when a numeric option (`column-width`, `gutter`, `stagger`) is negative, and when `wait-for-images-timeout` is non-numeric or negative.
+
+### Documentation
+
+- docs: Document the `data-masonry` JSON > friendly attribute > metadata default > built-in default precedence in the README.
+- docs: Add friendly `masonry-*` attributes and the new timeout option to `_schema.yml` for IDE autocompletion.
+- docs: Extend `example.qmd` to cover the precedence rules and the wait-for-images-timeout option.
+
 ## 0.3.0 (2026-05-24)
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This extension provides support for [`Masonry.js`](https://masonry.desandro.com/
 ## Installation
 
 ```sh
-quarto add mcanouil/quarto-masonry@0.4.0
+quarto add mcanouil/quarto-masonry@0.3.0
 ```
 
 This will install the extension under the `_extensions` subdirectory.  

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This extension provides support for [`Masonry.js`](https://masonry.desandro.com/
 ## Installation
 
 ```sh
-quarto add mcanouil/quarto-masonry@0.3.0
+quarto add mcanouil/quarto-masonry@0.4.0
 ```
 
 This will install the extension under the `_extensions` subdirectory.  
@@ -46,6 +46,15 @@ The supported attributes map to the matching [`Masonry.js` options](https://maso
 | `masonry-stagger` | `stagger` | Number of milliseconds or a CSS time. |
 | `masonry-item-selector` | `itemSelector` | Defaults to `.grid-item`. |
 
+#### Option precedence
+
+For each Masonry.js option, the value used at render is resolved in this order, highest priority first.
+
+1. A key explicitly set in the raw `data-masonry` JSON on the grid (never overwritten).
+2. The matching `masonry-*` attribute on the grid.
+3. The matching key in the document-level `masonry` metadata block.
+4. The extension's built-in default (currently only `itemSelector` defaults to `.grid-item`).
+
 ### Document-level defaults
 
 Set defaults for every grid in the document with a `masonry` metadata block, using the same option names without the `masonry-` prefix.
@@ -74,6 +83,18 @@ This bundles and uses [imagesLoaded](https://imagesloaded.desandro.com/).
 :::
 ::: {.grid-item}
 ![](image-2.jpg)
+:::
+::::
+```
+
+Add `masonry-wait-for-images-timeout="3000"` on a grid (or `wait-for-images-timeout: 3000` in the metadata block) to cap how long the extension waits before running the layout anyway.
+The value is in milliseconds.
+If imagesLoaded never fires, the layout still runs at the timeout instead of being silently skipped.
+
+```markdown
+:::: {.grid masonry-wait-for-images="true" masonry-wait-for-images-timeout="3000"}
+::: {.grid-item}
+![](image-1.jpg)
 :::
 ::::
 ```

--- a/_extensions/masonry/_extension.yml
+++ b/_extensions/masonry/_extension.yml
@@ -1,6 +1,6 @@
 title: Masonry.js JavaScript Library
 author: Mickaël Canouil
-version: 0.3.0
+version: 0.4.0
 quarto-required: ">=1.2.280"
 contributes:
   filters:

--- a/_extensions/masonry/_extension.yml
+++ b/_extensions/masonry/_extension.yml
@@ -1,6 +1,6 @@
 title: Masonry.js JavaScript Library
 author: Mickaël Canouil
-version: 0.4.0
+version: 0.3.0
 quarto-required: ">=1.2.280"
 contributes:
   filters:

--- a/_extensions/masonry/_modules/logging.lua
+++ b/_extensions/masonry/_modules/logging.lua
@@ -1,0 +1,62 @@
+--- MC Logging - Formatted log output for Quarto Lua filters and shortcodes
+--- @module "logging"
+--- @license MIT
+--- @copyright 2026 Mickaël Canouil
+--- @author Mickaël Canouil
+--- @version 1.0.0
+
+local M = {}
+
+-- ============================================================================
+-- LOGGING UTILITIES
+-- ============================================================================
+
+--- Format and log an error message with extension prefix.
+--- Provides standardised error messages with consistent formatting across extensions.
+--- Format: [extension-name] Message with details.
+---
+--- @param extension_name string The name of the extension (e.g., "external", "lua-env")
+--- @param message string The error message to display
+--- @usage M.log_error("external", "Could not open file 'example.md'.")
+function M.log_error(extension_name, message)
+  quarto.log.error('[' .. extension_name .. '] ' .. message)
+end
+
+--- Format and log a warning message with extension prefix.
+--- Provides standardised warning messages with consistent formatting across extensions.
+--- Format: [extension-name] Message with details.
+---
+--- @param extension_name string The name of the extension (e.g., "external", "lua-env")
+--- @param message string The warning message to display
+--- @usage M.log_warning("lua-env", "No variable name provided.")
+function M.log_warning(extension_name, message)
+  quarto.log.warning('[' .. extension_name .. '] ' .. message)
+end
+
+--- Format and log an output message with extension prefix.
+--- Provides standardised informational messages with consistent formatting across extensions.
+--- Format: [extension-name] Message with details.
+---
+--- @param extension_name string The name of the extension (e.g., "lua-env")
+--- @param message string The informational message to display
+--- @usage M.log_output("lua-env", "Exported metadata to: output.json")
+function M.log_output(extension_name, message)
+  quarto.log.output('[' .. extension_name .. '] ' .. message)
+end
+
+--- Format and log a debug message with extension prefix.
+--- Provides standardised debug messages with consistent formatting across extensions.
+--- Format: [extension-name] Message with details.
+---
+--- @param extension_name string The name of the extension (e.g., "lua-env")
+--- @param message string The debug message to display
+--- @usage M.log_debug("lua-env", "Variable 'x' has value: 42")
+function M.log_debug(extension_name, message)
+  quarto.log.debug('[' .. extension_name .. '] ' .. message)
+end
+
+-- ============================================================================
+-- MODULE EXPORT
+-- ============================================================================
+
+return M

--- a/_extensions/masonry/_schema.yml
+++ b/_extensions/masonry/_schema.yml
@@ -1,5 +1,6 @@
 # _schema.yml for "masonry" filter extension
-# Describes the document-level `masonry` metadata options for IDE tooling and validation.
+# Describes the document-level `masonry` metadata options and the per-grid
+# friendly attributes for IDE tooling and validation.
 
 $schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
 
@@ -43,3 +44,41 @@ options:
         type: boolean
         default: false
         description: "Defer layout until images inside each grid have loaded, using imagesLoaded."
+      wait-for-images-timeout:
+        type: number
+        description: "Maximum time in milliseconds to wait for images before running the layout anyway. Applied per grid when `wait-for-images` is enabled."
+
+attributes:
+  masonry-column-width:
+    anyOf:
+      - type: number
+      - type: string
+    description: "Width of a column, in pixels or as an item selector (Masonry.js `columnWidth`)."
+  masonry-gutter:
+    anyOf:
+      - type: number
+      - type: string
+    description: "Horizontal space between items, in pixels or as a gutter element selector (Masonry.js `gutter`)."
+  masonry-horizontal-order:
+    type: boolean
+    description: "Lay out items to maintain horizontal left-to-right order (Masonry.js `horizontalOrder`)."
+  masonry-percent-position:
+    type: boolean
+    description: "Set item positions in percentage values rather than pixels (Masonry.js `percentPosition`)."
+  masonry-transition-duration:
+    type: string
+    description: "Duration of the layout transition (Masonry.js `transitionDuration`)."
+  masonry-stagger:
+    anyOf:
+      - type: number
+      - type: string
+    description: "Stagger between transitions of subsequent items, in milliseconds or CSS time (Masonry.js `stagger`)."
+  masonry-item-selector:
+    type: string
+    description: "Selector for which child elements are laid out (Masonry.js `itemSelector`)."
+  masonry-wait-for-images:
+    type: boolean
+    description: "Defer this grid's layout until its images have loaded (per-grid override of `masonry.wait-for-images`)."
+  masonry-wait-for-images-timeout:
+    type: number
+    description: "Maximum time in milliseconds to wait for images on this grid before running the layout anyway."

--- a/_extensions/masonry/_schema.yml
+++ b/_extensions/masonry/_schema.yml
@@ -1,8 +1,8 @@
-# _schema.yml for "masonry" filter extension
+# Schema for the masonry extension
 # Describes the document-level `masonry` metadata options and the per-grid
 # friendly attributes for IDE tooling and validation.
 
-$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v2/extension-schema.json
 
 options:
   masonry:
@@ -10,31 +10,22 @@ options:
     description: "Document-level defaults applied to every `.grid` that does not set the matching attribute."
     properties:
       column-width:
-        anyOf:
-          - type: number
-          - type: string
+        type: [number, string]
         description: "Width of a column, in pixels or as an item selector (Masonry.js `columnWidth`)."
       gutter:
-        anyOf:
-          - type: number
-          - type: string
+        type: [number, string]
         description: "Horizontal space between items, in pixels or as a gutter element selector (Masonry.js `gutter`)."
       horizontal-order:
         type: boolean
-        default: false
         description: "Lay out items to maintain horizontal left-to-right order (Masonry.js `horizontalOrder`)."
       percent-position:
         type: boolean
-        default: false
         description: "Set item positions in percentage values rather than pixels (Masonry.js `percentPosition`)."
       transition-duration:
         type: string
-        default: "0.4s"
         description: "Duration of the layout transition (Masonry.js `transitionDuration`)."
       stagger:
-        anyOf:
-          - type: number
-          - type: string
+        type: [number, string]
         description: "Stagger between transitions of subsequent items, in milliseconds or CSS time (Masonry.js `stagger`)."
       item-selector:
         type: string
@@ -46,39 +37,40 @@ options:
         description: "Defer layout until images inside each grid have loaded, using imagesLoaded."
       wait-for-images-timeout:
         type: number
-        description: "Maximum time in milliseconds to wait for images before running the layout anyway. Applied per grid when `wait-for-images` is enabled."
+        minimum: 0
+        description: "Maximum time in milliseconds to wait for images before running the layout anyway, applied per grid when `wait-for-images` is enabled."
 
 attributes:
-  masonry-column-width:
-    anyOf:
-      - type: number
-      - type: string
-    description: "Width of a column, in pixels or as an item selector (Masonry.js `columnWidth`)."
-  masonry-gutter:
-    anyOf:
-      - type: number
-      - type: string
-    description: "Horizontal space between items, in pixels or as a gutter element selector (Masonry.js `gutter`)."
-  masonry-horizontal-order:
-    type: boolean
-    description: "Lay out items to maintain horizontal left-to-right order (Masonry.js `horizontalOrder`)."
-  masonry-percent-position:
-    type: boolean
-    description: "Set item positions in percentage values rather than pixels (Masonry.js `percentPosition`)."
-  masonry-transition-duration:
-    type: string
-    description: "Duration of the layout transition (Masonry.js `transitionDuration`)."
-  masonry-stagger:
-    anyOf:
-      - type: number
-      - type: string
-    description: "Stagger between transitions of subsequent items, in milliseconds or CSS time (Masonry.js `stagger`)."
-  masonry-item-selector:
-    type: string
-    description: "Selector for which child elements are laid out (Masonry.js `itemSelector`)."
-  masonry-wait-for-images:
-    type: boolean
-    description: "Defer this grid's layout until its images have loaded (per-grid override of `masonry.wait-for-images`)."
-  masonry-wait-for-images-timeout:
-    type: number
-    description: "Maximum time in milliseconds to wait for images on this grid before running the layout anyway."
+  grid:
+    masonry-column-width:
+      type: [number, string]
+      description: "Width of a column, in pixels or as an item selector (Masonry.js `columnWidth`)."
+    masonry-gutter:
+      type: [number, string]
+      description: "Horizontal space between items, in pixels or as a gutter element selector (Masonry.js `gutter`)."
+    masonry-horizontal-order:
+      type: boolean
+      description: "Lay out items to maintain horizontal left-to-right order (Masonry.js `horizontalOrder`)."
+    masonry-percent-position:
+      type: boolean
+      description: "Set item positions in percentage values rather than pixels (Masonry.js `percentPosition`)."
+    masonry-transition-duration:
+      type: string
+      description: "Duration of the layout transition (Masonry.js `transitionDuration`)."
+    masonry-stagger:
+      type: [number, string]
+      description: "Stagger between transitions of subsequent items, in milliseconds or CSS time (Masonry.js `stagger`)."
+    masonry-item-selector:
+      type: string
+      description: "Selector for which child elements are laid out (Masonry.js `itemSelector`)."
+    masonry-wait-for-images:
+      type: boolean
+      description: "Defer this grid's layout until its images have loaded (per-grid override of `masonry.wait-for-images`)."
+    masonry-wait-for-images-timeout:
+      type: number
+      minimum: 0
+      description: "Maximum time in milliseconds to wait for images on this grid before running the layout anyway."
+
+classes:
+  grid:
+    description: "Container laid out as a Masonry.js cascading grid."

--- a/_extensions/masonry/masonry-init.js
+++ b/_extensions/masonry/masonry-init.js
@@ -1,7 +1,9 @@
 /*!
  * masonry-init.js
  * Auto-initialises Masonry.js on every element carrying a data-masonry attribute.
- * Defers layout until images have loaded when data-masonry-wait-for-images is set.
+ * Defers layout until images have loaded when data-masonry-wait-for-images is set,
+ * with an optional data-masonry-wait-for-images-timeout (ms) fallback that triggers
+ * the layout if imagesLoaded never fires.
  * MIT License
  * by Mickaël Canouil
  */
@@ -9,11 +11,39 @@
 (function () {
   "use strict";
 
+  function readTimeout(element) {
+    var raw = element.getAttribute("data-masonry-wait-for-images-timeout");
+    if (raw === null) {
+      return null;
+    }
+    var n = Number(raw);
+    if (!isFinite(n) || n < 0) {
+      return null;
+    }
+    return n;
+  }
+
   function initialiseGrid(element) {
     var waitForImages = element.getAttribute("data-masonry-wait-for-images") === "true";
     if (waitForImages && typeof window.imagesLoaded === "function") {
-      window.imagesLoaded(element, function () {
+      var laidOut = false;
+      var runLayout = function () {
+        if (laidOut) {
+          return;
+        }
+        laidOut = true;
         new Masonry(element);
+      };
+      var timeoutMs = readTimeout(element);
+      var timer = null;
+      if (timeoutMs !== null) {
+        timer = window.setTimeout(runLayout, timeoutMs);
+      }
+      window.imagesLoaded(element, function () {
+        if (timer !== null) {
+          window.clearTimeout(timer);
+        }
+        runLayout();
       });
     } else {
       new Masonry(element);

--- a/_extensions/masonry/masonry.lua
+++ b/_extensions/masonry/masonry.lua
@@ -3,6 +3,9 @@
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil
 
+local logging = require(quarto.utils.resolve_path('_modules/logging.lua'):gsub('%.lua$', ''))
+local EXTENSION_NAME = 'masonry'
+
 --- Mapping from friendly attribute/metadata names to Masonry.js option keys.
 --- Keys are the friendly names (without the 'masonry-' attribute prefix);
 --- values describe the camelCase Masonry.js option and how to encode it as JSON.
@@ -23,22 +26,38 @@ local OPTION_DEFAULTS = {
   ['item-selector'] = '.grid-item'
 }
 
---- Document-level defaults gathered from the `masonry` metadata block.
---- @type table<string, string>
-local meta_defaults = {}
+--- Numeric options that must be non-negative when parsed as numbers.
+--- @type table<string, boolean>
+local NON_NEGATIVE_NUMERIC = {
+  ['column-width'] = true,
+  ['gutter'] = true,
+  ['stagger'] = true
+}
 
---- Whether imagesLoaded support is requested by document metadata.
---- @type boolean
-local meta_wait_for_images = false
+--- Document-level state. Reset at the start of each Pandoc pass so batch
+--- renders never leak state from a previous document.
+--- @type table
+local state = {
+  meta_defaults = {},
+  meta_wait_for_images = false,
+  meta_wait_for_images_timeout = nil,
+  imagesloaded_added = false
+}
 
---- Whether the imagesLoaded HTML dependency has already been injected.
---- @type boolean
-local imagesloaded_added = false
+--- Reset all document-level state. Call once per document at the start of the
+--- Pandoc pass.
+--- @return nil
+local function reset_state()
+  state.meta_defaults = {}
+  state.meta_wait_for_images = false
+  state.meta_wait_for_images_timeout = nil
+  state.imagesloaded_added = false
+end
 
 --- Add the imagesLoaded library as an HTML dependency once per document.
 --- @return nil
 local function ensure_imagesloaded()
-  if imagesloaded_added then
+  if state.imagesloaded_added then
     return
   end
   quarto.doc.add_html_dependency({
@@ -46,19 +65,73 @@ local function ensure_imagesloaded()
     version = '5.0.0',
     scripts = { 'imagesloaded.pkgd.min.js' }
   })
-  imagesloaded_added = true
+  state.imagesloaded_added = true
 end
 
 --- Escape a string for inclusion inside a double-quoted JSON value.
+--- Handles every character JSON requires escaped: backslash, double quote,
+--- and all C0 control characters (U+0000 through U+001F). Anything outside
+--- that range is passed through unchanged.
 --- @param value string The raw string value
 --- @return string The escaped string
 local function escape_json_string(value)
-  return value:gsub('\\', '\\\\'):gsub('"', '\\"')
+  value = value:gsub('\\', '\\\\'):gsub('"', '\\"')
+  value = value:gsub('[%z\1-\31]', function(c)
+    local byte = string.byte(c)
+    if byte == 8 then return '\\b' end
+    if byte == 9 then return '\\t' end
+    if byte == 10 then return '\\n' end
+    if byte == 12 then return '\\f' end
+    if byte == 13 then return '\\r' end
+    return string.format('\\u%04x', byte)
+  end)
+  return value
+end
+
+--- Validate a numeric option value. Emits a warning when the value cannot be
+--- parsed or is out of bounds; the original string is returned in either case
+--- so the user retains visibility of what they supplied.
+--- @param name string The friendly option name
+--- @param value string The raw string value
+--- @return string The original value
+local function validate_numeric(name, value)
+  if not NON_NEGATIVE_NUMERIC[name] then
+    return value
+  end
+  local n = tonumber(value)
+  if n == nil then
+    return value
+  end
+  if n < 0 then
+    logging.log_warning(EXTENSION_NAME,
+      "Option '" .. name .. "' is negative (" .. value .. "); Masonry.js expects a non-negative value.")
+  end
+  return value
+end
+
+--- Validate the wait-for-images timeout. Returns nil when invalid so the
+--- emitter falls back to the no-timeout behaviour. Emits a warning on every
+--- invalid value with context.
+--- @param raw string The raw timeout value
+--- @return number|nil The validated timeout in milliseconds
+local function validate_timeout(raw)
+  local n = tonumber(raw)
+  if n == nil then
+    logging.log_warning(EXTENSION_NAME,
+      "wait-for-images-timeout '" .. tostring(raw) .. "' is not a number; ignoring.")
+    return nil
+  end
+  if n < 0 then
+    logging.log_warning(EXTENSION_NAME,
+      "wait-for-images-timeout (" .. tostring(n) .. ") is negative; ignoring.")
+    return nil
+  end
+  return n
 end
 
 --- Encode a value as a JSON fragment according to the Masonry.js option kind.
 --- Numbers and booleans are emitted unquoted when they parse cleanly;
---- everything else falls back to a quoted string.
+--- everything else falls back to a quoted, properly escaped string.
 --- @param kind string The option kind ('number-or-string', 'boolean' or 'string')
 --- @param value string The raw string value
 --- @return string The JSON-encoded value
@@ -105,12 +178,13 @@ local function build_data_masonry(attributes, raw_json)
     if not present[spec.key] then
       local value = attributes[name]
       if value == nil then
-        value = meta_defaults[name]
+        value = state.meta_defaults[name]
       end
       if value == nil then
         value = OPTION_DEFAULTS[name]
       end
       if value ~= nil then
+        value = validate_numeric(name, value)
         fragments[#fragments + 1] = '"' .. spec.key .. '": ' .. encode_value(spec.kind, value)
       end
     end
@@ -130,11 +204,15 @@ local function read_metadata(meta)
   if config and type(config) == 'table' then
     for name, _ in pairs(OPTION_MAP) do
       if config[name] ~= nil then
-        meta_defaults[name] = pandoc.utils.stringify(config[name])
+        state.meta_defaults[name] = pandoc.utils.stringify(config[name])
       end
     end
     if config['wait-for-images'] ~= nil then
-      meta_wait_for_images = pandoc.utils.stringify(config['wait-for-images']) == 'true'
+      state.meta_wait_for_images = pandoc.utils.stringify(config['wait-for-images']) == 'true'
+    end
+    if config['wait-for-images-timeout'] ~= nil then
+      state.meta_wait_for_images_timeout =
+        validate_timeout(pandoc.utils.stringify(config['wait-for-images-timeout']))
     end
   end
 end
@@ -167,24 +245,37 @@ local function process_grid(div)
   end
 
   --- @type boolean Whether this grid should defer layout until images load
-  local wait_for_images = meta_wait_for_images
+  local wait_for_images = state.meta_wait_for_images
   local attr_wait = div.attributes['masonry-wait-for-images']
   if attr_wait ~= nil then
     wait_for_images = attr_wait == 'true'
     div.attributes['masonry-wait-for-images'] = nil
   end
+
+  --- Resolve the per-grid timeout. Attribute wins over metadata.
+  local timeout = state.meta_wait_for_images_timeout
+  local attr_timeout = div.attributes['masonry-wait-for-images-timeout']
+  if attr_timeout ~= nil then
+    timeout = validate_timeout(attr_timeout)
+    div.attributes['masonry-wait-for-images-timeout'] = nil
+  end
+
   if wait_for_images and div.attributes['data-masonry'] ~= nil then
     div.attributes['data-masonry-wait-for-images'] = 'true'
+    if timeout ~= nil then
+      div.attributes['data-masonry-wait-for-images-timeout'] = tostring(timeout)
+    end
     ensure_imagesloaded()
   end
 
   return div
 end
 
---- Process the whole document: gather metadata defaults, convert friendly
---- attributes on every `.grid` div, then inject the Masonry.js library, the
---- auto-initialisation script and, when image loading support is requested,
---- the imagesLoaded library as HTML dependencies for HTML-based outputs.
+--- Process the whole document: reset per-document state, gather metadata
+--- defaults, convert friendly attributes on every `.grid` div, then inject
+--- the Masonry.js library, the auto-initialisation script and, when image
+--- loading support is requested, the imagesLoaded library as HTML dependencies
+--- for HTML-based outputs.
 --- @param doc pandoc.Pandoc The document
 --- @return pandoc.Pandoc The processed document
 local function Pandoc(doc)
@@ -192,6 +283,7 @@ local function Pandoc(doc)
     return doc
   end
 
+  reset_state()
   read_metadata(doc.meta)
   doc.blocks = doc.blocks:walk({ Div = process_grid })
 

--- a/example.qmd
+++ b/example.qmd
@@ -160,6 +160,41 @@ The `masonry-*` attributes are converted into the `data-masonry` JSON for you, i
 :::
 ::::
 
+### Waiting for images with a timeout
+
+The `masonry-wait-for-images-timeout` attribute caps how long the extension waits for imagesLoaded before running the layout anyway, so the grid still appears if image loading stalls.
+
+```{=html}
+<details>
+<summary>Click to see the Markdown code!</summary>
+```
+
+```{.markdown}
+:::: {.grid masonry-wait-for-images="true" masonry-wait-for-images-timeout="3000"}
+::: {.grid-item}
+:::
+::: {.grid-item .grid-item--width2 .grid-item--height2}
+:::
+::: {.grid-item .grid-item--height3}
+:::
+::::
+```
+
+```{=html}
+</details>
+```
+
+:::: {.grid masonry-wait-for-images="true" masonry-wait-for-images-timeout="3000"}
+::: {.grid-item}
+:::
+::: {.grid-item .grid-item--width2 .grid-item--height2}
+:::
+::: {.grid-item .grid-item--height3}
+:::
+::: {.grid-item .grid-item--height2}
+:::
+::::
+
 ### With raw `data-masonry` JSON
 
 Writing the options yourself as raw JSON is still supported and takes precedence over the friendly attributes and metadata defaults.


### PR DESCRIPTION
Addresses review findings for the v0.4.0 cycle.

- Adds the `masonry-wait-for-images-timeout` attribute and matching metadata key, with a `setTimeout` fallback in `masonry-init.js` so the layout still runs when imagesLoaded never fires.
- Resets module-level state at the start of every Pandoc pass so batch renders no longer leak metadata defaults, wait-for-images settings, or the imagesLoaded dependency flag between documents.
- Escapes control characters (newline, tab, carriage return, and the full C0 range) in `data-masonry` JSON strings, fixing invalid JSON that previously occurred when option values contained literal newlines.
- Warns via `quarto.log.warning` when a numeric option (`column-width`, `gutter`, `stagger`) is negative, and when `wait-for-images-timeout` is non-numeric or negative.
- Documents the `data-masonry` JSON > `masonry-*` attribute > document metadata default > built-in default precedence in the README.
- Adds the friendly `masonry-*` attributes and the new timeout option to `_schema.yml` so IDE tooling can autocomplete and validate them.
- Extends `example.qmd` to cover the wait-for-images-timeout option.
- Vendors `_modules/logging.lua` from the shared-modules source to back the new warnings.
