### PR TITLE
feat: declare the vendored module in a manifest

### DIFF
--- a/_extensions/masonry/_dependencies.yml
+++ b/_extensions/masonry/_dependencies.yml
@@ -1,0 +1,11 @@
+schema: 1
+sources:
+  quarto-lua-modules:
+    origin: "https://github.com/mcanouil/quarto-lua-modules"
+    fetch: "{origin}/releases/download/{version}/{file}"
+    version: "2.1.0"
+    licence: MIT
+    files:
+      logging.lua:
+        sha256: "0c3ded6020d3739c91bb6a492328751b284d1ada5763a1b8ca6fc5536ac01c95"
+        runtime: any

--- a/_extensions/masonry/_vendor/quarto-lua-modules/LICENSE
+++ b/_extensions/masonry/_vendor/quarto-lua-modules/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mickaël Canouil
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/_extensions/masonry/_vendor/quarto-lua-modules/logging.lua
+++ b/_extensions/masonry/_vendor/quarto-lua-modules/logging.lua
@@ -3,7 +3,7 @@
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil
---- @version 1.0.0
+--- @version 2.1.0
 
 local M = {}
 

--- a/_extensions/masonry/masonry.lua
+++ b/_extensions/masonry/masonry.lua
@@ -3,7 +3,7 @@
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil
 
-local logging = require(quarto.utils.resolve_path('_modules/logging.lua'):gsub('%.lua$', ''))
+local logging = require(quarto.utils.resolve_path('_vendor/quarto-lua-modules/logging.lua'):gsub('%.lua$', ''))
 local EXTENSION_NAME = 'masonry'
 
 --- Mapping from friendly attribute/metadata names to Masonry.js option keys.

--- a/docs/_scripts/sync-extension.sh
+++ b/docs/_scripts/sync-extension.sh
@@ -3,9 +3,9 @@
 # Documentation Extension Sync
 # Mirrors the repository's own extension into the documentation project.
 #
-# @license %%license%%
-# @copyright %%year%% %%author%%
-# @author %%author%%
+# @license MIT License
+# @copyright 2026 Mickaël Canouil
+# @author Mickaël Canouil
 #
 # The website demonstrates the extension it documents, so the extension has to
 # be resolvable from docs/. Quarto builds its extension registry while reading


### PR DESCRIPTION
The extension kept its shared Lua module in `_extensions/masonry/_modules/`, copied in by hand with no record of where it came from.
This moves it onto a manifest at `_extensions/masonry/_dependencies.yml`, with the file under `_extensions/masonry/_vendor/`, so it names the release it came from and can be checked against it.
The manifest declares `logging.lua` from `quarto-lua-modules` 2.1.0, which is everything the extension loads.
The entry point's `require` is repointed to match, and nothing else about the extension changes.
The documentation site renders clean on all five pages.

This branch was also going to add a runtime check of the document configuration against `_schema.yml`, and that part has been removed rather than shipped.
The check would have been unable to help any configuration a user can write.
The extension reads its options from the top-level `masonry` metadata key, which is the form the documentation, the reference page and `example.qmd` all teach, and the validator does not read there at all.
The validator reads `extensions.masonry`, and `_schema.yml` nests every option under a further key named `masonry`, so the only declared key at the level the validator reads is `masonry` itself.
A check would therefore stay silent on the documented form and reject every real option name under the other one.
Probes confirmed both: a deliberate fault under the top-level key produced no message, and real option names under `extensions.masonry` came back as unrecognised keys.

Reporting faults against configurations that are in fact correct is worse than reporting nothing, so no check ships here.
Closing the gap means moving either the schema or the extension onto one namespace, which changes what the extension accepts, so it belongs in its own change.
Nothing in `_schema.yml` is touched, and there is no changelog entry, because this branch makes no user-facing change.
